### PR TITLE
port JavaProcessRule

### DIFF
--- a/processor/app.py
+++ b/processor/app.py
@@ -17,6 +17,7 @@ from processor.rules.mozilla_transform_rules import (
     DatesAndTimesRule,
     EnvironmentRule,
     ESRVersionRewrite,
+    JavaProcessRule,
     PluginContentURL,
     PluginRule,
     PluginUserComment,
@@ -174,7 +175,7 @@ class Processor:
                 AddonsRule(),
                 DatesAndTimesRule(),
                 # s.p.mozilla_transform_rules.OutOfMemoryBinaryRule
-                # s.p.mozilla_transform_rules.JavaProcessRule
+                JavaProcessRule(),
                 # s.p.mozilla_transform_rules.Winsock_LSPRule
 
                 # post processing of the processed crash

--- a/processor/rules/mozilla_transform_rules.py
+++ b/processor/rules/mozilla_transform_rules.py
@@ -190,6 +190,17 @@ class FennecBetaError20150430(Rule):
         return True
 
 
+class JavaProcessRule(Rule):
+    '''copy or initialize the java_stack_trace
+    '''
+
+    def action(self, crash_id, raw_crash, dumps, processed_crash):
+        processed_crash['java_stack_trace'] = raw_crash.setdefault(
+            'JavaStackTrace',
+            None
+        )
+
+
 class PluginContentURL(Rule):
     '''overwrite 'URL' with 'PluginContentURL' if it exists
     '''

--- a/tests/unittest/rules/test_mozilla_transform_rules.py
+++ b/tests/unittest/rules/test_mozilla_transform_rules.py
@@ -9,6 +9,7 @@ from processor.rules.mozilla_transform_rules import (
     DatesAndTimesRule,
     EnvironmentRule,
     ESRVersionRewrite,
+    JavaProcessRule,
     PluginContentURL,
     PluginRule,
     PluginUserComment,
@@ -262,6 +263,29 @@ class TestESRVersionRewrite:
 
         assert (failure.value.args[0] ==
             '"Version" missing from esr release raw_crash')
+
+
+class TestJavaProcessRule:
+
+    def test_everything_we_hoped_for(self, raw_crash):
+        raw_crash['JavaStackTrace'] = "this is a Java Stack trace"
+
+        processed_crash = {}
+
+        JavaProcessRule()(_, raw_crash, _, processed_crash)
+
+        assert 'java_stack_trace' in processed_crash
+        assert (processed_crash['java_stack_trace'] ==
+            raw_crash['JavaStackTrace'])
+
+
+    def test_missing_stuff(self, raw_crash):
+        # no raw_crash java stack trace
+        processed_crash = {}
+
+        JavaProcessRule()(_, raw_crash, _, processed_crash)
+
+        assert processed_crash['java_stack_trace'] == None
 
 
 class TestPluginContentURL:


### PR DESCRIPTION
ports over JavaProcessRule and associated tests. straightforward with few modifications. Using setdefault is an interesting choice. In a future version, consider revising.